### PR TITLE
Turn some methods into attributes and rename them

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -137,30 +137,32 @@ depend on the lower-level concepts of "streams" defined in [[!WHATWG-STREAMS]].
 
 # `UnidirectionalStreamsTransport` Mixin #  {#unidirectional-streams-transport}
 
-A <dfn interface>UnidirectionalStreamsTransport</dfn> can send and receive
-unidirectional streams.  Data within a stream is delivered in order, but data
-between streams may be delivered out of order.  Data is generally sent
-reliably, but retransmissions may be disabled or the stream may aborted to
-produce a form of unreliability.  All stream data is encrypted and
-congestion-controlled.
+A {{UnidirectionalStreamsTransport}} can send and receive unidirectional
+streams.  Data within a stream is delivered in order, but data between streams
+may be delivered out of order.  Data is generally sent reliably, but
+retransmissions may be disabled or the stream may aborted to produce a form of
+unreliability.  All stream data is encrypted and congestion-controlled.
 
 <pre class="idl">
 interface mixin UnidirectionalStreamsTransport {
-  Promise&lt;SendStream&gt; createSendStream(optional SendStreamParameters parameters = {});
-  ReadableStream receiveStreams();
+  Promise&lt;SendStream&gt; createUnidirectionalStream(optional SendStreamParameters parameters = {});
+  /* a ReadableStream of ReceiveStream objects */
+  readonly attribute ReadableStream incomingUnidirectionalStreams;
 };
 </pre>
 
 ## Methods ##  {##unidirectional-streams-transport-methods}
 
-: <dfn for="UnidirectionalStreamsTransport" method>createSendStream()</dfn>
+: <dfn for="UnidirectionalStreamsTransport" method>createUnidirectionalStream()</dfn>
 
-:: Creates a {{SendStream}} object.
+:: Creates a {{SendStream}} object for an outgoing unidirectional stream.  Note
+   that in some transports, the mere creation of a stream is not immediately
+   visible to the peer until it is used to send data.
 
-   When `createSendStream()` method is called, the user agent MUST run the
-   following steps:
+   When `createUnidirectionalStream()` method is called, the user agent MUST
+   run the following steps:
      1. Let |transport| be the `UnidirectionalStreamsTransport` on which
-        `createSendStream` is invoked.
+        `createUnidirectionalStream` is invoked.
      1. If |transport|'s {{WebTransport/state}} is `"closed"` or `"failed"`,
         immediately return a new [=rejected=] promise with a newly created
         {{InvalidStateError}} and abort these steps.
@@ -179,20 +181,19 @@ interface mixin UnidirectionalStreamsTransport {
          1. The |transport|'s state transitions to `"closed"` or `"failed"`.
          1. |p| has not been [=settled=].
 
-: <dfn for="UnidirectionalStreamsTransport" method>receiveStreams()</dfn>
-:: Returns a {{ReadableStream}} of {{ReceiveStream}}s that have been received
-   from the remote host.
+: <dfn for="UnidirectionalStreamsTransport" attribute>incomingUnidirectionalStreams</dfn>
+:: A {{ReadableStream}} of unidirectional streams, represented by
+   {{ReceiveStream}} object, that have been received from the remote host.
 
-   When `receiveStreams` is called, the user agent MUST run the following
-   steps:
+   The getter steps for `incomingUnidirectionalStreams` are:
      1. Let |transport| be the `UnidirectionalStreamsTransport` on which
-        `receiveStreams` is invoked.
+        `incomingUnidirectionalStreams` getter is invoked.
      1. Return the value of the {{[[ReceivedStreams]]}} internal slot.
      1. For each unidirectional stream received, create a corresponding
-        {{IncomingStream}} and insert it into {{[[ReceivedStreams]]}}. As data
+        {{ReceiveStream}} and insert it into {{[[ReceivedStreams]]}}. As data
         is received over the unidirectional stream, insert that data into the
-        corresponding `IncomingStream`.  When the remote side closes or aborts
-        the stream, close or abort the corresponding `IncomingStream`.
+        corresponding `ReceiveStream` object.  When the remote side closes or
+        aborts the stream, close or abort the corresponding `ReceiveStream`.
 
 ## Procedures ##  {##unidirectional-streams-transport-procedures}
 
@@ -223,16 +224,17 @@ dictionary SendStreamParameters {
 
 # `BidirectionalStreamsTransport` Mixin #  {#bidirectional-streams-transport}
 
-A <dfn interface>BidirectionalStreamsTransport</dfn> can send and receive
-bidirectional streams.  Data within a stream is delivered in order, but data
-between streams may be delivered out of order. Data is generally sent reliably,
-but retransmissions may be disabled or the stream may aborted to produce a form
-of unreliability.  All stream data is encrypted and congestion-controlled.
+A {{BidirectionalStreamsTransport}} can send and receive bidirectional streams.
+Data within a stream is delivered in order, but data between streams may be
+delivered out of order. Data is generally sent reliably, but retransmissions
+may be disabled or the stream may aborted to produce a form of unreliability.
+All stream data is encrypted and congestion-controlled.
 
 <pre class="idl">
 interface mixin BidirectionalStreamsTransport {
     Promise&lt;BidirectionalStream&gt; createBidirectionalStream();
-    ReadableStream receiveBidirectionalStreams();
+    /* a ReadableStream of BidirectionalStream objects */
+    readonly attribute ReadableStream incomingBidirectionalStreams;
 };
 </pre>
 
@@ -240,7 +242,9 @@ interface mixin BidirectionalStreamsTransport {
 ## Methods ##  {##bidirectional-streams-transport-methods}
 
 : <dfn for="BidirectionalStreamsTransport" method>createBidirectionalStream()</dfn>
-:: Creates a {{BidirectionalStream}} object.
+:: Creates a {{BidirectionalStream}} object for an outgoing bidirectional
+   stream.  Note that in some transports, the mere creation of a stream is not
+   immediately visible to the peer until it is used to send data.
 
    When `createBidirectionalStream` is called, the user agent MUST run the
    following steps:
@@ -270,12 +274,11 @@ interface mixin BidirectionalStreamsTransport {
        1. The |transport|'s state transitions to `"closed"` or `"failed"`.
        1. |p| has not been [=settled=].
 
-: <dfn for="BidirectionalStreamsTransport" method>receiveBidirectionalStreams()</dfn>
+: <dfn for="BidirectionalStreamsTransport" attribute>incomingBidirectionalStreams</dfn>
 :: Returns a {{ReadableStream}} of {{BidirectionalStream}}s that have been
    received from the remote host.
 
-   When `receiveBidirectionalStreams` method is called, the user agent MUST run
-   the following steps:
+   The getter steps for the `incomingBidirectionalStreams` attribute SHALL be:
 
      1. Let |transport| be the `BidirectionalStreamsTransport` on which
         `receiveBidirectionalStreams` is invoked.
@@ -313,8 +316,9 @@ Datagrams are encrypted and congestion controlled.
 <pre class="idl">
 interface mixin DatagramTransport {
     readonly attribute unsigned short maxDatagramSize;
-    WritableStream sendDatagrams();
-    ReadableStream receiveDatagrams();
+    /* both streams are streams of Uint8Array objects */
+    readonly attribute ReadableStream readableDatagrams;
+    readonly attribute WritableStream writableDatagrams;
 };
 </pre>
 
@@ -322,19 +326,17 @@ interface mixin DatagramTransport {
 
 : <dfn for="DatagramTransport" attribute>maxDatagramSize</dfn>
 :: The maximum size data that may be passed to
-   {{DatagramTransport/sendDatagrams}}.
+   {{DatagramTransport/writableDatagrams}}.
 
-## Methods ##  {#datagram-transport-methods}
-
-: <dfn for="DatagramTransport" method>sendDatagrams()</dfn>
+: <dfn for="DatagramTransport" attribute>writableDatagrams</dfn>
 :: Sends datagrams that are written to the returned {{WritableStream}}.
 
-   When `sendDatagrams` is called, the user agent MUST run the following steps:
+   When `writableDatagrams` is called, the user agent MUST run the following steps:
      1. Let |transport| be the {{DatagramTransport}} on which `sendDatagram` is
         invoked.
      1. Return the value of the {{[[SentDatagrams]]}} internal slot.
 
-: <dfn for="DatagramTransport" method>receiveDatagrams()</dfn>
+: <dfn for="DatagramTransport" attribute>readableDatagrams</dfn>
 :: Return the value of the {{[[ReceivedDatagrams]]}} internal slot.
 
    For each datagram received, insert it into {{[[ReceivedDatagrams]]}}. If too
@@ -662,7 +664,7 @@ The dictionary SHALL have the following attributes:
 :: The minimum RTT observed on the entire connection.
 : <dfn for="WebTransportStats" dict-member>numReceivedDatagramsDropped</dfn>
 :: The number of datagrams that were dropped, due to too many datagrams buffered
-   between calls to {{receiveDatagrams()}}.
+   between calls to {{readableDatagrams}}.
 
 # Interface Mixin `OutgoingStream` #  {#outgoing-stream}
 
@@ -748,6 +750,7 @@ either a {{ReceiveStream}} or a {{BidirectionalStream}}.
 <pre class="idl">
 [ Exposed=(Window,Worker) ]
 interface mixin IncomingStream {
+  /* a ReadableStream of Uint8Array */
   readonly attribute ReadableStream readable;
   readonly attribute Promise&lt;StreamAbortInfo&gt; readingAborted;
   void abortReading(optional StreamAbortInfo abortInfo = {});
@@ -900,12 +903,12 @@ willing to accept connections from the Web.
 *This section is non-normative.*
 
 Sending a buffer of datagrams can be achieved by using the
-{{DatagramTransport/sendDatagrams()}} method. In the following example
+{{DatagramTransport/writableDatagrams}} method. In the following example
 datagrams are only sent if the {{DatagramTransport}} is ready to send.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
-const writer = transport.sendDatagrams().getWriter();
+const writer = transport.writableDatagrams.getWriter();
 const datagrams = getDatagramsToSend();
 datagrams.forEach((datagram) => {
   await writer.ready;
@@ -918,14 +921,14 @@ datagrams.forEach((datagram) => {
 *This section is non-normative.*
 
 Sending datagrams at a fixed rate regardless if the transport is ready to send
-can be achieved by simply using {{DatagramTransport/sendDatagrams()}} and not
+can be achieved by simply using {{DatagramTransport/writableDatagrams}} and not
 using the `ready` attribute. More complex scenarios can utilize the `ready`
 attribute.
 
 <pre class="example" highlight="js">
 // Sends datagrams every 100 ms.
 const transport = getTransport();
-const writer = transport.sendDatagrams().getWriter();
+const writer = transport.writableDatagrams.getWriter();
 setInterval(() => {
   writer.write(createDatagram());
 }, 100);
@@ -936,12 +939,12 @@ setInterval(() => {
 *This section is non-normative.*
 
 Receiving datagrams can be achieved by calling
-{{DatagramTransport/receiveDatagrams()}} method, remembering to check for null
+{{DatagramTransport/readableDatagrams}} method, remembering to check for null
 values indicating that packets are not being processed quickly enough.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
-const reader = transport.receiveDatagrams().getReader();
+const reader = transport.readableDatagrams.getReader();
 while (true) {
   const {value: datagram, done} = await reader.read();
   if (done) {
@@ -955,13 +958,14 @@ while (true) {
 
 *This section is non-normative.*
 
-Reading from ReceiveStreams can be achieved by calling
-{{UnidirectionalStreamsTransport/receiveStreams()}} method, then getting the
-reader for each {{ReceiveStream}}.
+Reading from ReceiveStreams can be achieved by accessing
+{{UnidirectionalStreamsTransport/incomingUnidirectionalStreams}} attribute,
+then getting the reader for each {{ReceiveStream}}.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
-const receiveStreamReader = transport.receiveStreams().getReader();
+const receiveStreamReader =
+    transport.incomingUnidirectionalStreams.getReader();
 while (true) {
   const {value: receiveStream, done: readingReceiveStreamsDone} =
       await receiveStreamReader.read();

--- a/index.bs
+++ b/index.bs
@@ -183,11 +183,11 @@ interface mixin UnidirectionalStreamsTransport {
 
 : <dfn for="UnidirectionalStreamsTransport" attribute>incomingUnidirectionalStreams</dfn>
 :: A {{ReadableStream}} of unidirectional streams, each represented by a
-   {{ReceiveStream}} object, that have been received from the remote host."
+   {{ReceiveStream}} object, that have been received from the remote host.
 
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Let |transport| be the `UnidirectionalStreamsTransport` on which
-        `incomingUnidirectionalStreams` getter is invoked.
+        the `incomingUnidirectionalStreams` getter is invoked.
      1. Return the value of the {{[[ReceivedStreams]]}} internal slot.
      1. For each unidirectional stream received, create a corresponding
         {{ReceiveStream}} and insert it into {{[[ReceivedStreams]]}}. As data
@@ -315,8 +315,8 @@ Datagrams are encrypted and congestion controlled.
 interface mixin DatagramTransport {
     readonly attribute unsigned short maxDatagramSize;
     /* both streams are streams of Uint8Array objects */
-    readonly attribute ReadableStream readableDatagrams;
-    readonly attribute WritableStream writableDatagrams;
+    readonly attribute ReadableStream datagramReadable;
+    readonly attribute WritableStream datagramWritable;
 };
 </pre>
 
@@ -324,15 +324,15 @@ interface mixin DatagramTransport {
 
 : <dfn for="DatagramTransport" attribute>maxDatagramSize</dfn>
 :: The maximum size data that may be passed to
-   {{DatagramTransport/writableDatagrams}}.
+   {{DatagramTransport/datagramWritable}}.
 
-: <dfn for="DatagramTransport" attribute>writableDatagrams</dfn>
+: <dfn for="DatagramTransport" attribute>datagramWritable</dfn>
 :: Sends datagrams that are written to the returned {{WritableStream}}.
 
-   The getter steps for the `writableDatagrams` attribute SHALL be:
+   The getter steps for the `datagramWritable` attribute SHALL be:
      1. Return the value of the {{[[SentDatagrams]]}} internal slot.
 
-: <dfn for="DatagramTransport" attribute>readableDatagrams</dfn>
+: <dfn for="DatagramTransport" attribute>datagramReadable</dfn>
 :: Return the value of the {{[[ReceivedDatagrams]]}} internal slot.
 
    For each datagram received, insert it into {{[[ReceivedDatagrams]]}}. If too
@@ -660,7 +660,7 @@ The dictionary SHALL have the following attributes:
 :: The minimum RTT observed on the entire connection.
 : <dfn for="WebTransportStats" dict-member>numReceivedDatagramsDropped</dfn>
 :: The number of datagrams that were dropped, due to too many datagrams buffered
-   between calls to {{readableDatagrams}}.
+   between calls to {{datagramReadable}}.
 
 # Interface Mixin `OutgoingStream` #  {#outgoing-stream}
 
@@ -899,12 +899,12 @@ willing to accept connections from the Web.
 *This section is non-normative.*
 
 Sending a buffer of datagrams can be achieved by using the
-{{DatagramTransport/writableDatagrams}} attribute. In the following example
+{{DatagramTransport/datagramWritable}} attribute. In the following example
 datagrams are only sent if the {{DatagramTransport}} is ready to send.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
-const writer = transport.writableDatagrams.getWriter();
+const writer = transport.datagramWritable.getWriter();
 const datagrams = getDatagramsToSend();
 datagrams.forEach((datagram) => {
   await writer.ready;
@@ -917,14 +917,14 @@ datagrams.forEach((datagram) => {
 *This section is non-normative.*
 
 Sending datagrams at a fixed rate regardless if the transport is ready to send
-can be achieved by simply using {{DatagramTransport/writableDatagrams}} and not
+can be achieved by simply using {{DatagramTransport/datagramWritable}} and not
 using the `ready` attribute. More complex scenarios can utilize the `ready`
 attribute.
 
 <pre class="example" highlight="js">
 // Sends datagrams every 100 ms.
 const transport = getTransport();
-const writer = transport.writableDatagrams.getWriter();
+const writer = transport.datagramWritable.getWriter();
 setInterval(() => {
   writer.write(createDatagram());
 }, 100);
@@ -935,12 +935,12 @@ setInterval(() => {
 *This section is non-normative.*
 
 Receiving datagrams can be achieved by calling
-{{DatagramTransport/readableDatagrams}} attribute, remembering to check for
+{{DatagramTransport/datagramReadable}} attribute, remembering to check for
 null values indicating that packets are not being processed quickly enough.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
-const reader = transport.readableDatagrams.getReader();
+const reader = transport.datagramReadable.getReader();
 while (true) {
   const {value: datagram, done} = await reader.read();
   if (done) {

--- a/index.bs
+++ b/index.bs
@@ -332,7 +332,7 @@ interface mixin DatagramTransport {
 :: Sends datagrams that are written to the returned {{WritableStream}}.
 
    When `writableDatagrams` is called, the user agent MUST run the following steps:
-     1. Let |transport| be the {{DatagramTransport}} on which `sendDatagram` is
+     1. Let |transport| be the {{DatagramTransport}} on which `writableDatagrams` is
         invoked.
      1. Return the value of the {{[[SentDatagrams]]}} internal slot.
 
@@ -964,16 +964,16 @@ then getting the reader for each {{ReceiveStream}}.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
-const receiveStreamReader =
+const incomingStreamReader =
     transport.incomingUnidirectionalStreams.getReader();
 while (true) {
-  const {value: receiveStream, done: readingReceiveStreamsDone} =
-      await receiveStreamReader.read();
-  if (readingReceiveStreamsDone) {
+  const {value: incomingStream, done: readingIncomingStreamsDone} =
+      await incomingStreamReader.read();
+  if (readingIncomingStreamsDone) {
     break;
   }
-  // Process ReceiveStreams created by remote endpoint.
-  const chunkReader = receiveStream.readable.getReader();
+  // Process incoming ReceiveStreams created by remote endpoint.
+  const chunkReader = incomingStream.readable.getReader();
   while (true) {
     const {value: chunk, done: readingChunksDone} = await chunkReader.read();
     if (readingChunksDone) {

--- a/index.bs
+++ b/index.bs
@@ -182,8 +182,8 @@ interface mixin UnidirectionalStreamsTransport {
          1. |p| has not been [=settled=].
 
 : <dfn for="UnidirectionalStreamsTransport" attribute>incomingUnidirectionalStreams</dfn>
-:: A {{ReadableStream}} of unidirectional streams, represented by
-   {{ReceiveStream}} object, that have been received from the remote host.
+:: A {{ReadableStream}} of unidirectional streams, each represented by a
+   {{ReceiveStream}} object, that have been received from the remote host."
 
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Let |transport| be the `UnidirectionalStreamsTransport` on which
@@ -280,8 +280,6 @@ interface mixin BidirectionalStreamsTransport {
 
    The getter steps for the `incomingBidirectionalStreams` attribute SHALL be:
 
-     1. Let |transport| be the `BidirectionalStreamsTransport` on which
-        `receiveBidirectionalStreams` is invoked.
      1. Return the value of the {{[[ReceivedBidirectionalStreams]]}} internal slot.
      1. For each bidirectional stream received, create a corresponding
         {{BidirectionalStream}} and insert it into {{[[ReceivedBidirectionalStreams]]}}.
@@ -331,9 +329,7 @@ interface mixin DatagramTransport {
 : <dfn for="DatagramTransport" attribute>writableDatagrams</dfn>
 :: Sends datagrams that are written to the returned {{WritableStream}}.
 
-   When `writableDatagrams` is called, the user agent MUST run the following steps:
-     1. Let |transport| be the {{DatagramTransport}} on which `writableDatagrams` is
-        invoked.
+   The getter steps for the `writableDatagrams` attribute SHALL be:
      1. Return the value of the {{[[SentDatagrams]]}} internal slot.
 
 : <dfn for="DatagramTransport" attribute>readableDatagrams</dfn>
@@ -903,7 +899,7 @@ willing to accept connections from the Web.
 *This section is non-normative.*
 
 Sending a buffer of datagrams can be achieved by using the
-{{DatagramTransport/writableDatagrams}} method. In the following example
+{{DatagramTransport/writableDatagrams}} attribute. In the following example
 datagrams are only sent if the {{DatagramTransport}} is ready to send.
 
 <pre class="example" highlight="js">
@@ -939,8 +935,8 @@ setInterval(() => {
 *This section is non-normative.*
 
 Receiving datagrams can be achieved by calling
-{{DatagramTransport/readableDatagrams}} method, remembering to check for null
-values indicating that packets are not being processed quickly enough.
+{{DatagramTransport/readableDatagrams}} attribute, remembering to check for
+null values indicating that packets are not being processed quickly enough.
 
 <pre class="example" highlight="js">
 const transport = getTransport();
@@ -958,7 +954,7 @@ while (true) {
 
 *This section is non-normative.*
 
-Reading from ReceiveStreams can be achieved by accessing
+Reading from ReceiveStreams can be achieved by accessing the
 {{UnidirectionalStreamsTransport/incomingUnidirectionalStreams}} attribute,
 then getting the reader for each {{ReceiveStream}}.
 

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
-  <meta content="cf0520a6262f88899be2d2d5c9a0f3526e222457" name="document-revision">
+  <meta content="2c6a8de7441cc67c855f617b0c8b9c46461b57f1" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1482,7 +1482,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebTransport</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-09-18">18 September 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-09-24">24 September 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1553,7 +1553,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <a href="#datagram-transport"><span class="secno">6</span> <span class="content"><code>DatagramTransport</code> Mixin</span></a>
      <ol class="toc">
       <li><a href="#datagram-transport-attributes"><span class="secno">6.1</span> <span class="content">Attributes</span></a>
-      <li><a href="#datagram-transport-methods"><span class="secno">6.2</span> <span class="content">Methods</span></a>
      </ol>
     <li>
      <a href="#web-transport"><span class="secno">7</span> <span class="content"><code>WebTransport</code> Interface</span></a>
@@ -1656,27 +1655,29 @@ defined here. The IncomingStream, OutgoingStream, and BidirectionalStream
 defined here correspend to a higher level of abstraction that contain and
 depend on the lower-level concepts of "streams" defined in <a data-link-type="biblio" href="#biblio-whatwg-streams">[WHATWG-STREAMS]</a>.</p>
    <h2 class="heading settled" data-level="4" id="unidirectional-streams-transport"><span class="secno">4. </span><span class="content"><code>UnidirectionalStreamsTransport</code> Mixin</span><a class="self-link" href="#unidirectional-streams-transport"></a></h2>
-   <p>A <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="unidirectionalstreamstransport"><code>UnidirectionalStreamsTransport</code></dfn> can send and receive
-unidirectional streams.  Data within a stream is delivered in order, but data
-between streams may be delivered out of order.  Data is generally sent
-reliably, but retransmissions may be disabled or the stream may aborted to
-produce a form of unreliability.  All stream data is encrypted and
-congestion-controlled.</p>
-<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport"><c- g>UnidirectionalStreamsTransport</c-></a> {
-  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createsendstream" id="ref-for-dom-unidirectionalstreamstransport-createsendstream"><c- g>createSendStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters"><c- n>SendStreamParameters</c-></a> <dfn class="idl-code" data-dfn-for="UnidirectionalStreamsTransport/createSendStream(parameters), UnidirectionalStreamsTransport/createSendStream()" data-dfn-type="argument" data-export id="dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"><code><c- g>parameters</c-></code><a class="self-link" href="#dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"></a></dfn> = {});
-  <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams"><c- g>receiveStreams</c-></a>();
+   <p>A <code class="idl"><a data-link-type="idl" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport">UnidirectionalStreamsTransport</a></code> can send and receive unidirectional
+streams.  Data within a stream is delivered in order, but data between streams
+may be delivered out of order.  Data is generally sent reliably, but
+retransmissions may be disabled or the stream may aborted to produce a form of
+unreliability.  All stream data is encrypted and congestion-controlled.</p>
+<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="unidirectionalstreamstransport"><code><c- g>UnidirectionalStreamsTransport</c-></code></dfn> {
+  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createunidirectionalstream" id="ref-for-dom-unidirectionalstreamstransport-createunidirectionalstream"><c- g>createUnidirectionalStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters"><c- n>SendStreamParameters</c-></a> <dfn class="idl-code" data-dfn-for="UnidirectionalStreamsTransport/createUnidirectionalStream(parameters), UnidirectionalStreamsTransport/createUnidirectionalStream()" data-dfn-type="argument" data-export id="dom-unidirectionalstreamstransport-createunidirectionalstream-parameters-parameters"><code><c- g>parameters</c-></code><a class="self-link" href="#dom-unidirectionalstreamstransport-createunidirectionalstream-parameters-parameters"></a></dfn> = {});
+  /* a ReadableStream of ReceiveStream objects */
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams" id="ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams"><c- g>incomingUnidirectionalStreams</c-></a>;
 };
 </pre>
    <h3 class="heading settled" data-level="4.1" id="#unidirectional-streams-transport-methods"><span class="secno">4.1. </span><span class="content">Methods</span><a class="self-link" href="#%23unidirectional-streams-transport-methods"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="UnidirectionalStreamsTransport" data-dfn-type="method" data-export data-lt="createSendStream(parameters)|createSendStream()" id="dom-unidirectionalstreamstransport-createsendstream"><code>createSendStream()</code></dfn>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="UnidirectionalStreamsTransport" data-dfn-type="method" data-export data-lt="createUnidirectionalStream(parameters)|createUnidirectionalStream()" id="dom-unidirectionalstreamstransport-createunidirectionalstream"><code>createUnidirectionalStream()</code></dfn>
     <dd data-md>
-     <p>Creates a <code class="idl"><a data-link-type="idl" href="#sendstream" id="ref-for-sendstream①">SendStream</a></code> object.</p>
-     <p>When <code>createSendStream()</code> method is called, the user agent MUST run the
- following steps:</p>
+     <p>Creates a <code class="idl"><a data-link-type="idl" href="#sendstream" id="ref-for-sendstream①">SendStream</a></code> object for an outgoing unidirectional stream.  Note
+ that in some transports, the mere creation of a stream is not immediately
+ visible to the peer until it is used to send data.</p>
+     <p>When <code>createUnidirectionalStream()</code> method is called, the user agent MUST
+ run the following steps:</p>
      <ol>
       <li data-md>
-       <p>Let <var>transport</var> be the <code>UnidirectionalStreamsTransport</code> on which <code>createSendStream</code> is invoked.</p>
+       <p>Let <var>transport</var> be the <code>UnidirectionalStreamsTransport</code> on which <code>createUnidirectionalStream</code> is invoked.</p>
       <li data-md>
        <p>If <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-state" id="ref-for-dom-webtransport-state">state</a></code> is <code>"closed"</code> or <code>"failed"</code>,
   immediately return a new <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects⑤">rejected</a> promise with a newly created <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort these steps.</p>
@@ -1707,22 +1708,20 @@ congestion-controlled.</p>
          <p><var>p</var> has not been <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects⑨">settled</a>.</p>
        </ol>
      </ol>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="UnidirectionalStreamsTransport" data-dfn-type="method" data-export id="dom-unidirectionalstreamstransport-receivestreams"><code>receiveStreams()</code></dfn>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="UnidirectionalStreamsTransport" data-dfn-type="attribute" data-export data-lt="incomingUnidirectionalStreams|incomingUnidirectionalStreams()" id="dom-unidirectionalstreamstransport-incomingunidirectionalstreams"><code>incomingUnidirectionalStreams()</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class②">ReadableStream</a>, readonly</span>
     <dd data-md>
-     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class②">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream">ReceiveStream</a></code>s that have been received
- from the remote host.</p>
-     <p>When <code>receiveStreams</code> is called, the user agent MUST run the following
- steps:</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class③">ReadableStream</a></code> of unidirectional streams, represented by <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream">ReceiveStream</a></code> object, that have been received from the remote host.</p>
+     <p>The getter steps for <code>incomingUnidirectionalStreams</code> are:</p>
      <ol>
       <li data-md>
-       <p>Let <var>transport</var> be the <code>UnidirectionalStreamsTransport</code> on which <code>receiveStreams</code> is invoked.</p>
+       <p>Let <var>transport</var> be the <code>UnidirectionalStreamsTransport</code> on which <code>incomingUnidirectionalStreams</code> getter is invoked.</p>
       <li data-md>
        <p>Return the value of the <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot">[[ReceivedStreams]]</a></code> internal slot.</p>
       <li data-md>
-       <p>For each unidirectional stream received, create a corresponding <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream">IncomingStream</a></code> and insert it into <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot①">[[ReceivedStreams]]</a></code>. As data
+       <p>For each unidirectional stream received, create a corresponding <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream①">ReceiveStream</a></code> and insert it into <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot①">[[ReceivedStreams]]</a></code>. As data
   is received over the unidirectional stream, insert that data into the
-  corresponding <code>IncomingStream</code>.  When the remote side closes or aborts
-  the stream, close or abort the corresponding <code>IncomingStream</code>.</p>
+  corresponding <code>ReceiveStream</code> object.  When the remote side closes or
+  aborts the stream, close or abort the corresponding <code>ReceiveStream</code>.</p>
      </ol>
    </dl>
    <h3 class="heading settled" data-level="4.2" id="#unidirectional-streams-transport-procedures"><span class="secno">4.2. </span><span class="content">Procedures</span><a class="self-link" href="#%23unidirectional-streams-transport-procedures"></a></h3>
@@ -1750,21 +1749,24 @@ relating to stream configuration.</p>
 };
 </pre>
    <h2 class="heading settled" data-level="5" id="bidirectional-streams-transport"><span class="secno">5. </span><span class="content"><code>BidirectionalStreamsTransport</code> Mixin</span><a class="self-link" href="#bidirectional-streams-transport"></a></h2>
-   <p>A <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="bidirectionalstreamstransport"><code>BidirectionalStreamsTransport</code></dfn> can send and receive
-bidirectional streams.  Data within a stream is delivered in order, but data
-between streams may be delivered out of order. Data is generally sent reliably,
-but retransmissions may be disabled or the stream may aborted to produce a form
-of unreliability.  All stream data is encrypted and congestion-controlled.</p>
-<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport"><c- g>BidirectionalStreamsTransport</c-></a> {
+   <p>A <code class="idl"><a data-link-type="idl" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport">BidirectionalStreamsTransport</a></code> can send and receive bidirectional streams.
+Data within a stream is delivered in order, but data between streams may be
+delivered out of order. Data is generally sent reliably, but retransmissions
+may be disabled or the stream may aborted to produce a form of unreliability.
+All stream data is encrypted and congestion-controlled.</p>
+<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="bidirectionalstreamstransport"><code><c- g>BidirectionalStreamsTransport</c-></code></dfn> {
     <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream"><c- n>BidirectionalStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-createbidirectionalstream" id="ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream"><c- g>createBidirectionalStream</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class③"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-receivebidirectionalstreams"><c- g>receiveBidirectionalStreams</c-></a>();
+    /* a ReadableStream of BidirectionalStream objects */
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class④"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams"><c- g>incomingBidirectionalStreams</c-></a>;
 };
 </pre>
    <h3 class="heading settled" data-level="5.1" id="#bidirectional-streams-transport-methods"><span class="secno">5.1. </span><span class="content">Methods</span><a class="self-link" href="#%23bidirectional-streams-transport-methods"></a></h3>
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="BidirectionalStreamsTransport" data-dfn-type="method" data-export id="dom-bidirectionalstreamstransport-createbidirectionalstream"><code>createBidirectionalStream()</code></dfn>
     <dd data-md>
-     <p>Creates a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①">BidirectionalStream</a></code> object.</p>
+     <p>Creates a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①">BidirectionalStream</a></code> object for an outgoing bidirectional
+ stream.  Note that in some transports, the mere creation of a stream is not
+ immediately visible to the peer until it is used to send data.</p>
      <p>When <code>createBidirectionalStream</code> is called, the user agent MUST run the
  following steps:</p>
      <ol>
@@ -1804,12 +1806,11 @@ of unreliability.  All stream data is encrypted and congestion-controlled.</p>
          <p><var>p</var> has not been <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects①⑤">settled</a>.</p>
        </ol>
      </ol>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="BidirectionalStreamsTransport" data-dfn-type="method" data-export id="dom-bidirectionalstreamstransport-receivebidirectionalstreams"><code>receiveBidirectionalStreams()</code></dfn>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="BidirectionalStreamsTransport" data-dfn-type="attribute" data-export data-lt="incomingBidirectionalStreams|incomingBidirectionalStreams()" id="dom-bidirectionalstreamstransport-incomingbidirectionalstreams"><code>incomingBidirectionalStreams()</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑤">ReadableStream</a>, readonly</span>
     <dd data-md>
-     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class④">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream④">BidirectionalStream</a></code>s that have been
+     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑥">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream④">BidirectionalStream</a></code>s that have been
  received from the remote host.</p>
-     <p>When <code>receiveBidirectionalStreams</code> method is called, the user agent MUST run
- the following steps:</p>
+     <p>The getter steps for the <code>incomingBidirectionalStreams</code> attribute SHALL be:</p>
      <ol>
       <li data-md>
        <p>Let <var>transport</var> be the <code>BidirectionalStreamsTransport</code> on which <code>receiveBidirectionalStreams</code> is invoked.</p>
@@ -1847,22 +1848,20 @@ Datagrams are sent out of order, unreliably, and have a limited maximum size.
 Datagrams are encrypted and congestion controlled.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#datagramtransport" id="ref-for-datagramtransport"><c- g>DatagramTransport</c-></a> {
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-datagramtransport-maxdatagramsize" id="ref-for-dom-datagramtransport-maxdatagramsize"><c- g>maxDatagramSize</c-></a>;
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams"><c- g>sendDatagrams</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑤"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams"><c- g>receiveDatagrams</c-></a>();
+    /* both streams are streams of Uint8Array objects */
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑦"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-datagramtransport-readabledatagrams" id="ref-for-dom-datagramtransport-readabledatagrams"><c- g>readableDatagrams</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-datagramtransport-writabledatagrams" id="ref-for-dom-datagramtransport-writabledatagrams"><c- g>writableDatagrams</c-></a>;
 };
 </pre>
    <h3 class="heading settled" data-level="6.1" id="datagram-transport-attributes"><span class="secno">6.1. </span><span class="content">Attributes</span><a class="self-link" href="#datagram-transport-attributes"></a></h3>
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DatagramTransport" data-dfn-type="attribute" data-export id="dom-datagramtransport-maxdatagramsize"><code>maxDatagramSize</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①">unsigned short</a>, readonly</span>
     <dd data-md>
-     <p>The maximum size data that may be passed to <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams①">sendDatagrams</a></code>.</p>
-   </dl>
-   <h3 class="heading settled" data-level="6.2" id="datagram-transport-methods"><span class="secno">6.2. </span><span class="content">Methods</span><a class="self-link" href="#datagram-transport-methods"></a></h3>
-   <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DatagramTransport" data-dfn-type="method" data-export id="dom-datagramtransport-senddatagrams"><code>sendDatagrams()</code></dfn>
+     <p>The maximum size data that may be passed to <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-writabledatagrams" id="ref-for-dom-datagramtransport-writabledatagrams①">writableDatagrams</a></code>.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DatagramTransport" data-dfn-type="attribute" data-export id="dom-datagramtransport-readabledatagrams"><code>readableDatagrams</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑧">ReadableStream</a>, readonly</span>
     <dd data-md>
      <p>Sends datagrams that are written to the returned <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class②">WritableStream</a></code>.</p>
-     <p>When <code>sendDatagrams</code> is called, the user agent MUST run the following steps:</p>
+     <p>When <code>writableDatagrams</code> is called, the user agent MUST run the following steps:</p>
      <ol>
       <li data-md>
        <p>Let <var>transport</var> be the <code class="idl"><a data-link-type="idl" href="#datagramtransport" id="ref-for-datagramtransport①">DatagramTransport</a></code> on which <code>sendDatagram</code> is
@@ -1870,7 +1869,7 @@ Datagrams are encrypted and congestion controlled.</p>
       <li data-md>
        <p>Return the value of the <code class="idl"><a data-link-type="idl" href="#dom-webtransport-sentdatagrams-slot" id="ref-for-dom-webtransport-sentdatagrams-slot">[[SentDatagrams]]</a></code> internal slot.</p>
      </ol>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DatagramTransport" data-dfn-type="method" data-export id="dom-datagramtransport-receivedatagrams"><code>receiveDatagrams()</code></dfn>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DatagramTransport" data-dfn-type="attribute" data-export id="dom-datagramtransport-writabledatagrams"><code>writableDatagrams</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class③">WritableStream</a>, readonly</span>
     <dd data-md>
      <p>Return the value of the <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receiveddatagrams-slot" id="ref-for-dom-webtransport-receiveddatagrams-slot">[[ReceivedDatagrams]]</a></code> internal slot.</p>
      <p>For each datagram received, insert it into <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receiveddatagrams-slot" id="ref-for-dom-webtransport-receiveddatagrams-slot①">[[ReceivedDatagrams]]</a></code>. If too
@@ -1920,19 +1919,19 @@ agent MUST run the following steps:</p>
  representing a sequence of <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream">OutgoingStream</a></code> objects, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="WebTransport" data-dfn-type="attribute" data-export id="dom-webtransport-receivedstreams-slot"><code>[[ReceivedStreams]]</code></dfn> internal slot
- representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑥">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①">IncomingStream</a></code> objects, initialized
+ representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑨">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream">IncomingStream</a></code> objects, initialized
  to empty.</p>
     <li data-md>
-     <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="WebTransport" data-dfn-type="attribute" data-export id="dom-webtransport-receivedbidirectionalstreams-slot"><code>[[ReceivedBidirectionalStreams]]</code></dfn> internal slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑦">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream⑨">BidirectionalStream</a></code> objects, initialized to empty.</p>
+     <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="WebTransport" data-dfn-type="attribute" data-export id="dom-webtransport-receivedbidirectionalstreams-slot"><code>[[ReceivedBidirectionalStreams]]</code></dfn> internal slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⓪">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream⑨">BidirectionalStream</a></code> objects, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="WebTransport" data-dfn-type="attribute" data-export id="dom-webtransport-webtransportstate-slot"><code>[[WebTransportState]]</code></dfn> internal
  slot, initialized to <code>"connecting"</code>.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="WebTransport" data-dfn-type="attribute" data-export id="dom-webtransport-sentdatagrams-slot"><code>[[SentDatagrams]]</code></dfn> internal slot
- representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class③">WritableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array">Uint8Array</a></code>s, initialized to empty.</p>
+ representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class④">WritableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array">Uint8Array</a></code>s, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="WebTransport" data-dfn-type="attribute" data-export id="dom-webtransport-receiveddatagrams-slot"><code>[[ReceivedDatagrams]]</code></dfn> internal
- slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑧">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array①">Uint8Array</a></code>s, initialized to
+ slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①①">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array①">Uint8Array</a></code>s, initialized to
  empty.</p>
     <li data-md>
      <p>If the scheme of <var>parsedURL</var> is <code>quic-transport</code>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>, <a data-link-type="dfn" href="#initialize-webtransport-over-quic" id="ref-for-initialize-webtransport-over-quic">initialize WebTransport over QUIC</a>.</p>
@@ -2117,9 +2116,9 @@ without key rotation.</p>
       <li data-md>
        <p>Let <var>transport</var> be the <code class="idl"><a data-link-type="idl" href="#webtransport" id="ref-for-webtransport⑥">WebTransport</a></code>.</p>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑨">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot②">[[ReceivedStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①②">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot②">[[ReceivedStreams]]</a></code> internal slot.</p>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⓪">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedbidirectionalstreams-slot" id="ref-for-dom-webtransport-receivedbidirectionalstreams-slot③">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①③">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedbidirectionalstreams-slot" id="ref-for-dom-webtransport-receivedbidirectionalstreams-slot③">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
       <li data-md>
        <p>For each <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream①">OutgoingStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-outgoingstreams-slot" id="ref-for-dom-webtransport-outgoingstreams-slot②">[[OutgoingStreams]]</a></code> internal slot run the following:</p>
        <ol>
@@ -2135,9 +2134,9 @@ without key rotation.</p>
  an error alert). When the WebTransport’s internal <code class="idl"><a data-link-type="idl" href="#dom-webtransport-webtransportstate-slot" id="ref-for-dom-webtransport-webtransportstate-slot⑨">[[WebTransportState]]</a></code> slot transitions to <code>failed</code> the user agent MUST run the following steps:</p>
      <ol>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①①">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot③">[[ReceivedStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①④">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedstreams-slot" id="ref-for-dom-webtransport-receivedstreams-slot③">[[ReceivedStreams]]</a></code> internal slot.</p>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①②">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedbidirectionalstreams-slot" id="ref-for-dom-webtransport-receivedbidirectionalstreams-slot④">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑤">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-receivedbidirectionalstreams-slot" id="ref-for-dom-webtransport-receivedbidirectionalstreams-slot④">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
       <li data-md>
        <p>For each <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream③">OutgoingStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-webtransport-outgoingstreams-slot" id="ref-for-dom-webtransport-outgoingstreams-slot④">[[OutgoingStreams]]</a></code> internal slot run the following:</p>
        <ol>
@@ -2216,14 +2215,14 @@ impossible to define for pooled connections.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WebTransportStats" data-dfn-type="dict-member" data-export id="dom-webtransportstats-numreceiveddatagramsdropped"><code>numReceivedDatagramsDropped</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤">unsigned long</a></span>
     <dd data-md>
      <p>The number of datagrams that were dropped, due to too many datagrams buffered
- between calls to <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams①">receiveDatagrams()</a></code>.</p>
+ between calls to <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-readabledatagrams" id="ref-for-dom-datagramtransport-readabledatagrams①">readableDatagrams</a></code>.</p>
    </dl>
    <h2 class="heading settled" data-level="8" id="outgoing-stream"><span class="secno">8. </span><span class="content">Interface Mixin <code>OutgoingStream</code></span><a class="self-link" href="#outgoing-stream"></a></h2>
    <p>An <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="outgoingstream"><code>OutgoingStream</code></dfn> is a stream that can be written to, as
 either a <code class="idl"><a data-link-type="idl" href="#sendstream" id="ref-for-sendstream④">SendStream</a></code> or a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①⓪">BidirectionalStream</a></code>.</p>
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#outgoingstream" id="ref-for-outgoingstream④"><c- g>OutgoingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class④"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable"><c- g>writable</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑤"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable"><c- g>writable</c-></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-outgoingstream-writingaborted" id="ref-for-dom-outgoingstream-writingaborted"><c- g>writingAborted</c-></a>;
   <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-outgoingstream-abortwriting" id="ref-for-dom-outgoingstream-abortwriting"><c- g>abortWriting</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo①"><c- n>StreamAbortInfo</c-></a> <dfn class="idl-code" data-dfn-for="OutgoingStream/abortWriting(abortInfo), OutgoingStream/abortWriting()" data-dfn-type="argument" data-export id="dom-outgoingstream-abortwriting-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code><a class="self-link" href="#dom-outgoingstream-abortwriting-abortinfo-abortinfo"></a></dfn> = {});
 };
@@ -2234,13 +2233,13 @@ either a <code class="idl"><a data-link-type="idl" href="#sendstream" id="ref-fo
     <li data-md>
      <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream⑥">OutgoingStream</a></code>.</p>
     <li data-md>
-     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable-slot"><code>[[Writable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑤">WritableStream</a></code>.</p>
+     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable-slot"><code>[[Writable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑥">WritableStream</a></code>.</p>
    </ol>
    <h3 class="heading settled" data-level="8.2" id="outgoing-stream-attributes"><span class="secno">8.2. </span><span class="content">Attributes</span><a class="self-link" href="#outgoing-stream-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable"><code>writable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑥">WritableStream</a>, readonly</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable"><code>writable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑦">WritableStream</a>, readonly</span>
     <dd data-md>
-     <p>The <code>writable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑦">WritableStream</a></code> (of bytes) that can
+     <p>The <code>writable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑧">WritableStream</a></code> (of bytes) that can
  be used to write to the <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream⑦">OutgoingStream</a></code>. On getting it MUST return the
  value of the <code class="idl"><a data-link-type="idl" href="#dom-outgoingstream-writable-slot" id="ref-for-dom-outgoingstream-writable-slot">[[Writable]]</a></code> slot.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writingaborted"><code>writingAborted</code></dfn>, <span> of type Promise&lt;<a data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo②">StreamAbortInfo</a>>, readonly</span>
@@ -2303,30 +2302,31 @@ QUIC, in either a RST_STREAM frame or a STOP_SENDING frame).</p>
    </dl>
    <h2 class="heading settled" data-level="9" id="incoming-stream"><span class="secno">9. </span><span class="content">Interface Mixin <code>IncomingStream</code></span><a class="self-link" href="#incoming-stream"></a></h2>
    <p>An <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="incomingstream"><code>IncomingStream</code></dfn> is a stream that can be read from, as
-either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream①">ReceiveStream</a></code> or a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①①">BidirectionalStream</a></code>.</p>
+either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream②">ReceiveStream</a></code> or a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①①">BidirectionalStream</a></code>.</p>
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream" id="ref-for-incomingstream②"><c- g>IncomingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①③"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable"><c- g>readable</c-></a>;
+<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream" id="ref-for-incomingstream①"><c- g>IncomingStream</c-></a> {
+  /* a ReadableStream of Uint8Array */
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑥"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable"><c- g>readable</c-></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑤"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-incomingstream-readingaborted" id="ref-for-dom-incomingstream-readingaborted"><c- g>readingAborted</c-></a>;
   <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-abortreading" id="ref-for-dom-incomingstream-abortreading"><c- g>abortReading</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑥"><c- n>StreamAbortInfo</c-></a> <dfn class="idl-code" data-dfn-for="IncomingStream/abortReading(abortInfo), IncomingStream/abortReading()" data-dfn-type="argument" data-export id="dom-incomingstream-abortreading-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code><a class="self-link" href="#dom-incomingstream-abortreading-abortinfo-abortinfo"></a></dfn> = {});
   <c- b>Promise</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer"><c- b>ArrayBuffer</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-arraybuffer" id="ref-for-dom-incomingstream-arraybuffer"><c- g>arrayBuffer</c-></a>();
 };
 </pre>
    <h3 class="heading settled" data-level="9.1" id="incoming-stream-overview"><span class="secno">9.1. </span><span class="content">Overview</span><a class="self-link" href="#incoming-stream-overview"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream③">IncomingStream</a></code> will initialize with the following:</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream②">IncomingStream</a></code> will initialize with the following:</p>
    <ol>
     <li data-md>
-     <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream④">IncomingStream</a></code>.</p>
+     <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream③">IncomingStream</a></code>.</p>
     <li data-md>
-     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable-slot"><code>[[Readable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①④">ReadableStream</a></code>.</p>
+     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable-slot"><code>[[Readable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑦">ReadableStream</a></code>.</p>
    </ol>
    <h3 class="heading settled" data-level="9.2" id="incoming-stream-attributes"><span class="secno">9.2. </span><span class="content">Attributes</span><a class="self-link" href="#incoming-stream-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable"><code>readable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑤">ReadableStream</a>, readonly</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable"><code>readable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑧">ReadableStream</a>, readonly</span>
     <dd data-md>
-     <p>The <code>readable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑥">ReadableStream</a></code> that can
- be used to read from the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑤">IncomingStream</a></code>. On getting it MUST return the
- value of the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑥">IncomingStream</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-incomingstream-readable-slot" id="ref-for-dom-incomingstream-readable-slot">[[Readable]]</a></code> slot.</p>
+     <p>The <code>readable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑨">ReadableStream</a></code> that can
+ be used to read from the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream④">IncomingStream</a></code>. On getting it MUST return the
+ value of the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑤">IncomingStream</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-incomingstream-readable-slot" id="ref-for-dom-incomingstream-readable-slot">[[Readable]]</a></code> slot.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readingaborted"><code>readingAborted</code></dfn>, <span> of type Promise&lt;<a data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑦">StreamAbortInfo</a>>, readonly</span>
     <dd data-md>
      <p>The <code>readingAborted</code> attribute represents a promise that is <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects②⓪">fulfilled</a> when the a message from the remote side aborting the stream is received.
@@ -2334,7 +2334,7 @@ either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref
   this mesage, the user agent MUST run the following:</p>
      <ol>
       <li data-md>
-       <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑦">IncomingStream</a></code> object for which the abort
+       <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑥">IncomingStream</a></code> object for which the abort
  message was received.</p>
       <li data-md>
        <p>Let <var>transport</var> be the <code class="idl"><a data-link-type="idl" href="#webtransport" id="ref-for-webtransport①①">WebTransport</a></code>, which the <var>stream</var> was created
@@ -2349,13 +2349,13 @@ either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="method" data-export data-lt="abortReading(abortInfo)|abortReading()" id="dom-incomingstream-abortreading"><code>abortReading()</code></dfn>
     <dd data-md>
-     <p>A hard shutdown of the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑧">IncomingStream</a></code>. It may be called regardless of
- whether the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑨">IncomingStream</a></code> was created by the local or remote peer. When
+     <p>A hard shutdown of the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑦">IncomingStream</a></code>. It may be called regardless of
+ whether the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑧">IncomingStream</a></code> was created by the local or remote peer. When
  the <code>abortWriting</code> method is called, the user agent MUST run the following
  steps:</p>
      <ol>
       <li data-md>
-       <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①⓪">IncomingStream</a></code> object which is about to abort
+       <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑨">IncomingStream</a></code> object which is about to abort
   reading.</p>
       <li data-md>
        <p>Let <var>transport</var> be the <code class="idl"><a data-link-type="idl" href="#webtransport" id="ref-for-webtransport①②">WebTransport</a></code>, which the <var>stream</var> was created
@@ -2380,7 +2380,7 @@ either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="bidirectionalstream"><code><c- g>BidirectionalStream</c-></code></dfn> {
 };
 <a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①②"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#outgoingstream" id="ref-for-outgoingstream①②"><c- n>OutgoingStream</c-></a>;
-<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①③"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①①"><c- n>IncomingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①③"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①⓪"><c- n>IncomingStream</c-></a>;
 </pre>
    <h2 class="heading settled" data-level="11" id="send-stream"><span class="secno">11. </span><span class="content">Interface <code>SendStream</code></span><a class="self-link" href="#send-stream"></a></h2>
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
@@ -2392,7 +2392,7 @@ either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="receivestream"><code><c- g>ReceiveStream</c-></code></dfn> {
 };
-<a class="n" data-link-type="idl-name" href="#receivestream" id="ref-for-receivestream②"><c- n>ReceiveStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①②"><c- n>IncomingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#receivestream" id="ref-for-receivestream③"><c- n>ReceiveStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①①"><c- n>IncomingStream</c-></a>;
 </pre>
    <h2 class="heading settled" data-level="13" id="privacy-security"><span class="secno">13. </span><span class="content">Privacy and Security Considerations</span><a class="self-link" href="#privacy-security"></a></h2>
    <p>This section is non-normative; it specifies no new behaviour, but instead
@@ -2447,10 +2447,10 @@ willing to accept connections from the Web.</p>
    <h2 class="heading settled" data-level="14" id="examples"><span class="secno">14. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <h3 class="heading settled" data-level="14.1" id="example-datagrams"><span class="secno">14.1. </span><span class="content">Sending a buffer of datagrams</span><a class="self-link" href="#example-datagrams"></a></h3>
    <p><em>This section is non-normative.</em></p>
-   <p>Sending a buffer of datagrams can be achieved by using the <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams②">sendDatagrams()</a></code> method. In the following example
+   <p>Sending a buffer of datagrams can be achieved by using the <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-writabledatagrams" id="ref-for-dom-datagramtransport-writabledatagrams②">writableDatagrams</a></code> method. In the following example
 datagrams are only sent if the <code class="idl"><a data-link-type="idl" href="#datagramtransport" id="ref-for-datagramtransport④">DatagramTransport</a></code> is ready to send.</p>
-<pre class="example highlight" id="example-874bd655"><a class="self-link" href="#example-874bd655"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
-<c- kr>const</c-> writer <c- o>=</c-> transport<c- p>.</c->sendDatagrams<c- p>().</c->getWriter<c- p>();</c->
+<pre class="example highlight" id="example-e634fb1d"><a class="self-link" href="#example-e634fb1d"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
+<c- kr>const</c-> writer <c- o>=</c-> transport<c- p>.</c->writableDatagrams<c- p>.</c->getWriter<c- p>();</c->
 <c- kr>const</c-> datagrams <c- o>=</c-> getDatagramsToSend<c- p>();</c->
 datagrams<c- p>.</c->forEach<c- p>((</c->datagram<c- p>)</c-> <c- p>=></c-> <c- p>{</c->
   await writer<c- p>.</c->ready<c- p>;</c->
@@ -2460,21 +2460,21 @@ datagrams<c- p>.</c->forEach<c- p>((</c->datagram<c- p>)</c-> <c- p>=></c-> <c- 
    <h3 class="heading settled" data-level="14.2" id="example-fixed-rate"><span class="secno">14.2. </span><span class="content">Sending datagrams at a fixed rate</span><a class="self-link" href="#example-fixed-rate"></a></h3>
    <p><em>This section is non-normative.</em></p>
    <p>Sending datagrams at a fixed rate regardless if the transport is ready to send
-can be achieved by simply using <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams③">sendDatagrams()</a></code> and not
+can be achieved by simply using <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-writabledatagrams" id="ref-for-dom-datagramtransport-writabledatagrams③">writableDatagrams</a></code> and not
 using the <code>ready</code> attribute. More complex scenarios can utilize the <code>ready</code> attribute.</p>
-<pre class="example highlight" id="example-6c14e5fe"><a class="self-link" href="#example-6c14e5fe"></a><c- c1>// Sends datagrams every 100 ms.</c->
+<pre class="example highlight" id="example-4c777b31"><a class="self-link" href="#example-4c777b31"></a><c- c1>// Sends datagrams every 100 ms.</c->
 <c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
-<c- kr>const</c-> writer <c- o>=</c-> transport<c- p>.</c->sendDatagrams<c- p>().</c->getWriter<c- p>();</c->
+<c- kr>const</c-> writer <c- o>=</c-> transport<c- p>.</c->writableDatagrams<c- p>.</c->getWriter<c- p>();</c->
 setInterval<c- p>(()</c-> <c- p>=></c-> <c- p>{</c->
   writer<c- p>.</c->write<c- p>(</c->createDatagram<c- p>());</c->
 <c- p>},</c-> <c- mi>100</c-><c- p>);</c->
 </pre>
    <h3 class="heading settled" data-level="14.3" id="example-receiving-datagrams"><span class="secno">14.3. </span><span class="content">Receiving datagrams</span><a class="self-link" href="#example-receiving-datagrams"></a></h3>
    <p><em>This section is non-normative.</em></p>
-   <p>Receiving datagrams can be achieved by calling <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams②">receiveDatagrams()</a></code> method, remembering to check for null
+   <p>Receiving datagrams can be achieved by calling <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-readabledatagrams" id="ref-for-dom-datagramtransport-readabledatagrams②">readableDatagrams</a></code> method, remembering to check for null
 values indicating that packets are not being processed quickly enough.</p>
-<pre class="example highlight" id="example-8116bd90"><a class="self-link" href="#example-8116bd90"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
-<c- kr>const</c-> reader <c- o>=</c-> transport<c- p>.</c->receiveDatagrams<c- p>().</c->getReader<c- p>();</c->
+<pre class="example highlight" id="example-0c34c926"><a class="self-link" href="#example-0c34c926"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
+<c- kr>const</c-> reader <c- o>=</c-> transport<c- p>.</c->readableDatagrams<c- p>.</c->getReader<c- p>();</c->
 <c- k>while</c-> <c- p>(</c-><c- kc>true</c-><c- p>)</c-> <c- p>{</c->
   <c- kr>const</c-> <c- p>{</c->value<c- o>:</c-> datagram<c- p>,</c-> done<c- p>}</c-> <c- o>=</c-> await reader<c- p>.</c->read<c- p>();</c->
   <c- k>if</c-> <c- p>(</c->done<c- p>)</c-> <c- p>{</c->
@@ -2485,10 +2485,11 @@ values indicating that packets are not being processed quickly enough.</p>
 </pre>
    <h3 class="heading settled" data-level="14.4" id="example-receiving-from-receivestream"><span class="secno">14.4. </span><span class="content">Receiving from ReceiveStream</span><a class="self-link" href="#example-receiving-from-receivestream"></a></h3>
    <p><em>This section is non-normative.</em></p>
-   <p>Reading from ReceiveStreams can be achieved by calling <code class="idl"><a data-link-type="idl" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams①">receiveStreams()</a></code> method, then getting the
-reader for each <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream③">ReceiveStream</a></code>.</p>
-<pre class="example highlight" id="example-5ead2914"><a class="self-link" href="#example-5ead2914"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
-<c- kr>const</c-> receiveStreamReader <c- o>=</c-> transport<c- p>.</c->receiveStreams<c- p>().</c->getReader<c- p>();</c->
+   <p>Reading from ReceiveStreams can be achieved by accessing <code class="idl"><a data-link-type="idl" href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams" id="ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams①">incomingUnidirectionalStreams</a></code> attribute,
+then getting the reader for each <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream④">ReceiveStream</a></code>.</p>
+<pre class="example highlight" id="example-499a270a"><a class="self-link" href="#example-499a270a"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
+<c- kr>const</c-> receiveStreamReader <c- o>=</c->
+    transport<c- p>.</c->incomingUnidirectionalStreams<c- p>.</c->getReader<c- p>();</c->
 <c- k>while</c-> <c- p>(</c-><c- kc>true</c-><c- p>)</c-> <c- p>{</c->
   <c- kr>const</c-> <c- p>{</c->value<c- o>:</c-> receiveStream<c- p>,</c-> done<c- o>:</c-> readingReceiveStreamsDone<c- p>}</c-> <c- o>=</c->
       await receiveStreamReader<c- p>.</c->read<c- p>();</c->
@@ -2668,8 +2669,8 @@ and has been adapted for use in this specification.</p>
    <li><a href="#dom-webtransport-webtransport">constructor(url)</a><span>, in §7</span>
    <li><a href="#dom-webtransport-webtransport">constructor(url, options)</a><span>, in §7</span>
    <li><a href="#dom-bidirectionalstreamstransport-createbidirectionalstream">createBidirectionalStream()</a><span>, in §5.1</span>
-   <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream()</a><span>, in §4.1</span>
-   <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream(parameters)</a><span>, in §4.1</span>
+   <li><a href="#dom-unidirectionalstreamstransport-createunidirectionalstream">createUnidirectionalStream()</a><span>, in §4.1</span>
+   <li><a href="#dom-unidirectionalstreamstransport-createunidirectionalstream">createUnidirectionalStream(parameters)</a><span>, in §4.1</span>
    <li><a href="#custom-certificate-requirements">custom certificate requirements</a><span>, in §7.4</span>
    <li><a href="#datagramtransport">DatagramTransport</a><span>, in §6</span>
    <li>
@@ -2681,7 +2682,11 @@ and has been adapted for use in this specification.</p>
    <li><a href="#dom-webtransportstate-failed">"failed"</a><span>, in §7.5</span>
    <li><a href="#dom-webtransport-getstats">getStats()</a><span>, in §7.3</span>
    <li><a href="#immediate-close">Immediate Close</a><span>, in §7.3</span>
+   <li><a href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams">incomingBidirectionalStreams</a><span>, in §5.1</span>
+   <li><a href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams">incomingBidirectionalStreams()</a><span>, in §5.1</span>
    <li><a href="#incomingstream">IncomingStream</a><span>, in §9</span>
+   <li><a href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams">incomingUnidirectionalStreams</a><span>, in §4.1</span>
+   <li><a href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams">incomingUnidirectionalStreams()</a><span>, in §4.1</span>
    <li><a href="#initialize-webtransport-over-http">initialize WebTransport over HTTP</a><span>, in §7.1</span>
    <li><a href="#initialize-webtransport-over-quic">initialize WebTransport over QUIC</a><span>, in §7.1</span>
    <li><a href="#dom-datagramtransport-maxdatagramsize">maxDatagramSize</a><span>, in §6.1</span>
@@ -2696,16 +2701,13 @@ and has been adapted for use in this specification.</p>
    <li><a href="#dom-webtransportstats-packetssent">packetsSent</a><span>, in §7.7</span>
    <li><a href="#dom-incomingstream-readable">readable</a><span>, in §9.2</span>
    <li><a href="#dom-incomingstream-readable-slot">[[Readable]]</a><span>, in §9.1</span>
+   <li><a href="#dom-datagramtransport-readabledatagrams">readableDatagrams</a><span>, in §6.1</span>
    <li><a href="#dom-incomingstream-readingaborted">readingAborted</a><span>, in §9.2</span>
    <li><a href="#dom-webtransportcloseinfo-reason">reason</a><span>, in §7.6</span>
-   <li><a href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams">receiveBidirectionalStreams()</a><span>, in §5.1</span>
-   <li><a href="#dom-datagramtransport-receivedatagrams">receiveDatagrams()</a><span>, in §6.2</span>
    <li><a href="#dom-webtransport-receivedbidirectionalstreams-slot">[[ReceivedBidirectionalStreams]]</a><span>, in §7.1</span>
    <li><a href="#dom-webtransport-receiveddatagrams-slot">[[ReceivedDatagrams]]</a><span>, in §7.1</span>
    <li><a href="#dom-webtransport-receivedstreams-slot">[[ReceivedStreams]]</a><span>, in §7.1</span>
    <li><a href="#receivestream">ReceiveStream</a><span>, in §12</span>
-   <li><a href="#dom-unidirectionalstreamstransport-receivestreams">receiveStreams()</a><span>, in §4.1</span>
-   <li><a href="#dom-datagramtransport-senddatagrams">sendDatagrams()</a><span>, in §6.2</span>
    <li><a href="#sendstream">SendStream</a><span>, in §11</span>
    <li><a href="#dictdef-sendstreamparameters">SendStreamParameters</a><span>, in §4.3</span>
    <li><a href="#dom-webtransport-sentdatagrams-slot">[[SentDatagrams]]</a><span>, in §7.1</span>
@@ -2725,6 +2727,7 @@ and has been adapted for use in this specification.</p>
    <li><a href="#dom-webtransport-webtransport">WebTransport(url, options)</a><span>, in §7</span>
    <li><a href="#dom-outgoingstream-writable-slot">[[Writable]]</a><span>, in §8.1</span>
    <li><a href="#dom-outgoingstream-writable">writable</a><span>, in §8.2</span>
+   <li><a href="#dom-datagramtransport-writabledatagrams">writableDatagrams</a><span>, in §6.1</span>
    <li><a href="#dom-outgoingstream-writingaborted">writingAborted</a><span>, in §8.2</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-concept-event">
@@ -3004,15 +3007,16 @@ and has been adapted for use in this specification.</p>
    <ul>
     <li><a href="#ref-for-rs-class">3. Terminology</a>
     <li><a href="#ref-for-rs-class①">4. UnidirectionalStreamsTransport Mixin</a>
-    <li><a href="#ref-for-rs-class②">4.1. Methods</a>
-    <li><a href="#ref-for-rs-class③">5. BidirectionalStreamsTransport Mixin</a>
-    <li><a href="#ref-for-rs-class④">5.1. Methods</a>
-    <li><a href="#ref-for-rs-class⑤">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-rs-class⑥">7.1. Constructor</a> <a href="#ref-for-rs-class⑦">(2)</a> <a href="#ref-for-rs-class⑧">(3)</a>
-    <li><a href="#ref-for-rs-class⑨">7.5. WebTransportState Enum</a> <a href="#ref-for-rs-class①⓪">(2)</a> <a href="#ref-for-rs-class①①">(3)</a> <a href="#ref-for-rs-class①②">(4)</a>
-    <li><a href="#ref-for-rs-class①③">9. Interface Mixin IncomingStream</a>
-    <li><a href="#ref-for-rs-class①④">9.1. Overview</a>
-    <li><a href="#ref-for-rs-class①⑤">9.2. Attributes</a> <a href="#ref-for-rs-class①⑥">(2)</a>
+    <li><a href="#ref-for-rs-class②">4.1. Methods</a> <a href="#ref-for-rs-class③">(2)</a>
+    <li><a href="#ref-for-rs-class④">5. BidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-rs-class⑤">5.1. Methods</a> <a href="#ref-for-rs-class⑥">(2)</a>
+    <li><a href="#ref-for-rs-class⑦">6. DatagramTransport Mixin</a>
+    <li><a href="#ref-for-rs-class⑧">6.1. Attributes</a>
+    <li><a href="#ref-for-rs-class⑨">7.1. Constructor</a> <a href="#ref-for-rs-class①⓪">(2)</a> <a href="#ref-for-rs-class①①">(3)</a>
+    <li><a href="#ref-for-rs-class①②">7.5. WebTransportState Enum</a> <a href="#ref-for-rs-class①③">(2)</a> <a href="#ref-for-rs-class①④">(3)</a> <a href="#ref-for-rs-class①⑤">(4)</a>
+    <li><a href="#ref-for-rs-class①⑥">9. Interface Mixin IncomingStream</a>
+    <li><a href="#ref-for-rs-class①⑦">9.1. Overview</a>
+    <li><a href="#ref-for-rs-class①⑧">9.2. Attributes</a> <a href="#ref-for-rs-class①⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ws-class">
@@ -3020,11 +3024,11 @@ and has been adapted for use in this specification.</p>
    <ul>
     <li><a href="#ref-for-ws-class">3. Terminology</a>
     <li><a href="#ref-for-ws-class①">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-ws-class②">6.2. Methods</a>
-    <li><a href="#ref-for-ws-class③">7.1. Constructor</a>
-    <li><a href="#ref-for-ws-class④">8. Interface Mixin OutgoingStream</a>
-    <li><a href="#ref-for-ws-class⑤">8.1. Overview</a>
-    <li><a href="#ref-for-ws-class⑥">8.2. Attributes</a> <a href="#ref-for-ws-class⑦">(2)</a>
+    <li><a href="#ref-for-ws-class②">6.1. Attributes</a> <a href="#ref-for-ws-class③">(2)</a>
+    <li><a href="#ref-for-ws-class④">7.1. Constructor</a>
+    <li><a href="#ref-for-ws-class⑤">8. Interface Mixin OutgoingStream</a>
+    <li><a href="#ref-for-ws-class⑥">8.1. Overview</a>
+    <li><a href="#ref-for-ws-class⑦">8.2. Attributes</a> <a href="#ref-for-ws-class⑧">(2)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -3150,23 +3154,26 @@ and has been adapted for use in this specification.</p>
    <dd>E. Rescorla. <a href="https://tools.ietf.org/html/rfc8446">The Transport Layer Security (TLS) Protocol Version 1.3</a>. August 2018. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc8446">https://tools.ietf.org/html/rfc8446</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport⑤"><c- g>UnidirectionalStreamsTransport</c-></a> {
-  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream⑥"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createsendstream" id="ref-for-dom-unidirectionalstreamstransport-createsendstream①"><c- g>createSendStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters②"><c- n>SendStreamParameters</c-></a> <a href="#dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"><code><c- g>parameters</c-></code></a> = {});
-  <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑦"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams②"><c- g>receiveStreams</c-></a>();
+<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a href="#unidirectionalstreamstransport"><code><c- g>UnidirectionalStreamsTransport</c-></code></a> {
+  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream⑥"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createunidirectionalstream" id="ref-for-dom-unidirectionalstreamstransport-createunidirectionalstream①"><c- g>createUnidirectionalStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters②"><c- n>SendStreamParameters</c-></a> <a href="#dom-unidirectionalstreamstransport-createunidirectionalstream-parameters-parameters"><code><c- g>parameters</c-></code></a> = {});
+  /* a ReadableStream of ReceiveStream objects */
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①①⓪"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams" id="ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams②"><c- g>incomingUnidirectionalStreams</c-></a>;
 };
 
 <c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters①①"><c- g>SendStreamParameters</c-></a> {
 };
 
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport⑥"><c- g>BidirectionalStreamsTransport</c-></a> {
+<c- b>interface</c-> <c- b>mixin</c-> <a href="#bidirectionalstreamstransport"><code><c- g>BidirectionalStreamsTransport</c-></code></a> {
     <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①④"><c- n>BidirectionalStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-createbidirectionalstream" id="ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream②"><c- g>createBidirectionalStream</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class③①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-receivebidirectionalstreams①"><c- g>receiveBidirectionalStreams</c-></a>();
+    /* a ReadableStream of BidirectionalStream objects */
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class④①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams①"><c- g>incomingBidirectionalStreams</c-></a>;
 };
 
 <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#datagramtransport" id="ref-for-datagramtransport⑤"><c- g>DatagramTransport</c-></a> {
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-datagramtransport-maxdatagramsize" id="ref-for-dom-datagramtransport-maxdatagramsize①"><c- g>maxDatagramSize</c-></a>;
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class①①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams④"><c- g>sendDatagrams</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑤①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams③"><c- g>receiveDatagrams</c-></a>();
+    /* both streams are streams of Uint8Array objects */
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑦①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-datagramtransport-readabledatagrams" id="ref-for-dom-datagramtransport-readabledatagrams③"><c- g>readableDatagrams</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class①①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-datagramtransport-writabledatagrams" id="ref-for-dom-datagramtransport-writabledatagrams④"><c- g>writableDatagrams</c-></a>;
 };
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
@@ -3214,7 +3221,7 @@ and has been adapted for use in this specification.</p>
 
 [ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#outgoingstream" id="ref-for-outgoingstream④①"><c- g>OutgoingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class④①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable①"><c- g>writable</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑤①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable①"><c- g>writable</c-></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑨"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-outgoingstream-writingaborted" id="ref-for-dom-outgoingstream-writingaborted①"><c- g>writingAborted</c-></a>;
   <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-outgoingstream-abortwriting" id="ref-for-dom-outgoingstream-abortwriting①"><c- g>abortWriting</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo①①"><c- n>StreamAbortInfo</c-></a> <a href="#dom-outgoingstream-abortwriting-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code></a> = {});
 };
@@ -3224,8 +3231,9 @@ and has been adapted for use in this specification.</p>
 };
 
 [ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream" id="ref-for-incomingstream②①"><c- g>IncomingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①③①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable①"><c- g>readable</c-></a>;
+<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream" id="ref-for-incomingstream①②"><c- g>IncomingStream</c-></a> {
+  /* a ReadableStream of Uint8Array */
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑥①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable①"><c- g>readable</c-></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑤①"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-incomingstream-readingaborted" id="ref-for-dom-incomingstream-readingaborted①"><c- g>readingAborted</c-></a>;
   <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-abortreading" id="ref-for-dom-incomingstream-abortreading①"><c- g>abortReading</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑥①"><c- n>StreamAbortInfo</c-></a> <a href="#dom-incomingstream-abortreading-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code></a> = {});
   <c- b>Promise</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer①"><c- b>ArrayBuffer</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-arraybuffer" id="ref-for-dom-incomingstream-arraybuffer①"><c- g>arrayBuffer</c-></a>();
@@ -3235,7 +3243,7 @@ and has been adapted for use in this specification.</p>
 <c- b>interface</c-> <a href="#bidirectionalstream"><code><c- g>BidirectionalStream</c-></code></a> {
 };
 <a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①②①"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#outgoingstream" id="ref-for-outgoingstream①②①"><c- n>OutgoingStream</c-></a>;
-<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①③①"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①①①"><c- n>IncomingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①③①"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①⓪①"><c- n>IncomingStream</c-></a>;
 
 [ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <a href="#sendstream"><code><c- g>SendStream</c-></code></a> {
@@ -3245,7 +3253,7 @@ and has been adapted for use in this specification.</p>
 [ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <a href="#receivestream"><code><c- g>ReceiveStream</c-></code></a> {
 };
-<a class="n" data-link-type="idl-name" href="#receivestream" id="ref-for-receivestream②①"><c- n>ReceiveStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①②①"><c- n>IncomingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#receivestream" id="ref-for-receivestream③①"><c- n>ReceiveStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①①①"><c- n>IncomingStream</c-></a>;
 
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
@@ -3266,17 +3274,17 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
     <li><a href="#ref-for-unidirectionalstreamstransport③">7. WebTransport Interface</a> <a href="#ref-for-unidirectionalstreamstransport④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-unidirectionalstreamstransport-createsendstream">
-   <b><a href="#dom-unidirectionalstreamstransport-createsendstream">#dom-unidirectionalstreamstransport-createsendstream</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-unidirectionalstreamstransport-createunidirectionalstream">
+   <b><a href="#dom-unidirectionalstreamstransport-createunidirectionalstream">#dom-unidirectionalstreamstransport-createunidirectionalstream</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-unidirectionalstreamstransport-createsendstream">4. UnidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-dom-unidirectionalstreamstransport-createunidirectionalstream">4. UnidirectionalStreamsTransport Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-unidirectionalstreamstransport-receivestreams">
-   <b><a href="#dom-unidirectionalstreamstransport-receivestreams">#dom-unidirectionalstreamstransport-receivestreams</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-unidirectionalstreamstransport-incomingunidirectionalstreams">
+   <b><a href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams">#dom-unidirectionalstreamstransport-incomingunidirectionalstreams</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-unidirectionalstreamstransport-receivestreams">4. UnidirectionalStreamsTransport Mixin</a>
-    <li><a href="#ref-for-dom-unidirectionalstreamstransport-receivestreams①">14.4. Receiving from ReceiveStream</a>
+    <li><a href="#ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams">4. UnidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams①">14.4. Receiving from ReceiveStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="add-the-sendstream">
@@ -3308,10 +3316,10 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
     <li><a href="#ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream①">5.1. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bidirectionalstreamstransport-receivebidirectionalstreams">
-   <b><a href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams">#dom-bidirectionalstreamstransport-receivebidirectionalstreams</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-bidirectionalstreamstransport-incomingbidirectionalstreams">
+   <b><a href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams">#dom-bidirectionalstreamstransport-incomingbidirectionalstreams</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-bidirectionalstreamstransport-receivebidirectionalstreams">5. BidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams">5. BidirectionalStreamsTransport Mixin</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="add-the-bidirectionalstream">
@@ -3324,7 +3332,7 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
    <b><a href="#datagramtransport">#datagramtransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datagramtransport">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-datagramtransport①">6.2. Methods</a>
+    <li><a href="#ref-for-datagramtransport①">6.1. Attributes</a>
     <li><a href="#ref-for-datagramtransport②">7. WebTransport Interface</a> <a href="#ref-for-datagramtransport③">(2)</a>
     <li><a href="#ref-for-datagramtransport④">14.1. Sending a buffer of datagrams</a>
    </ul>
@@ -3335,21 +3343,21 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
     <li><a href="#ref-for-dom-datagramtransport-maxdatagramsize">6. DatagramTransport Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datagramtransport-senddatagrams">
-   <b><a href="#dom-datagramtransport-senddatagrams">#dom-datagramtransport-senddatagrams</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-datagramtransport-readabledatagrams">
+   <b><a href="#dom-datagramtransport-readabledatagrams">#dom-datagramtransport-readabledatagrams</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-datagramtransport-senddatagrams">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-dom-datagramtransport-senddatagrams①">6.1. Attributes</a>
-    <li><a href="#ref-for-dom-datagramtransport-senddatagrams②">14.1. Sending a buffer of datagrams</a>
-    <li><a href="#ref-for-dom-datagramtransport-senddatagrams③">14.2. Sending datagrams at a fixed rate</a>
+    <li><a href="#ref-for-dom-datagramtransport-readabledatagrams">6. DatagramTransport Mixin</a>
+    <li><a href="#ref-for-dom-datagramtransport-readabledatagrams①">7.7. WebTransportStats Dictionary</a>
+    <li><a href="#ref-for-dom-datagramtransport-readabledatagrams②">14.3. Receiving datagrams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datagramtransport-receivedatagrams">
-   <b><a href="#dom-datagramtransport-receivedatagrams">#dom-datagramtransport-receivedatagrams</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-datagramtransport-writabledatagrams">
+   <b><a href="#dom-datagramtransport-writabledatagrams">#dom-datagramtransport-writabledatagrams</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-datagramtransport-receivedatagrams">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-dom-datagramtransport-receivedatagrams①">7.7. WebTransportStats Dictionary</a>
-    <li><a href="#ref-for-dom-datagramtransport-receivedatagrams②">14.3. Receiving datagrams</a>
+    <li><a href="#ref-for-dom-datagramtransport-writabledatagrams">6. DatagramTransport Mixin</a>
+    <li><a href="#ref-for-dom-datagramtransport-writabledatagrams①">6.1. Attributes</a>
+    <li><a href="#ref-for-dom-datagramtransport-writabledatagrams②">14.1. Sending a buffer of datagrams</a>
+    <li><a href="#ref-for-dom-datagramtransport-writabledatagrams③">14.2. Sending datagrams at a fixed rate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webtransport">
@@ -3422,13 +3430,13 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
   <aside class="dfn-panel" data-for="dom-webtransport-sentdatagrams-slot">
    <b><a href="#dom-webtransport-sentdatagrams-slot">#dom-webtransport-sentdatagrams-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-webtransport-sentdatagrams-slot">6.2. Methods</a>
+    <li><a href="#ref-for-dom-webtransport-sentdatagrams-slot">6.1. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-webtransport-receiveddatagrams-slot">
    <b><a href="#dom-webtransport-receiveddatagrams-slot">#dom-webtransport-receiveddatagrams-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-webtransport-receiveddatagrams-slot">6.2. Methods</a> <a href="#ref-for-dom-webtransport-receiveddatagrams-slot①">(2)</a>
+    <li><a href="#ref-for-dom-webtransport-receiveddatagrams-slot">6.1. Attributes</a> <a href="#ref-for-dom-webtransport-receiveddatagrams-slot①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="initialize-webtransport-over-quic">
@@ -3689,14 +3697,13 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
   <aside class="dfn-panel" data-for="incomingstream">
    <b><a href="#incomingstream">#incomingstream</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-incomingstream">4.1. Methods</a>
-    <li><a href="#ref-for-incomingstream①">7.1. Constructor</a>
-    <li><a href="#ref-for-incomingstream②">9. Interface Mixin IncomingStream</a>
-    <li><a href="#ref-for-incomingstream③">9.1. Overview</a> <a href="#ref-for-incomingstream④">(2)</a>
-    <li><a href="#ref-for-incomingstream⑤">9.2. Attributes</a> <a href="#ref-for-incomingstream⑥">(2)</a> <a href="#ref-for-incomingstream⑦">(3)</a>
-    <li><a href="#ref-for-incomingstream⑧">9.3. Methods</a> <a href="#ref-for-incomingstream⑨">(2)</a> <a href="#ref-for-incomingstream①⓪">(3)</a>
-    <li><a href="#ref-for-incomingstream①①">10. Interface BidirectionalStream</a>
-    <li><a href="#ref-for-incomingstream①②">12. Interface ReceiveStream</a>
+    <li><a href="#ref-for-incomingstream">7.1. Constructor</a>
+    <li><a href="#ref-for-incomingstream①">9. Interface Mixin IncomingStream</a>
+    <li><a href="#ref-for-incomingstream②">9.1. Overview</a> <a href="#ref-for-incomingstream③">(2)</a>
+    <li><a href="#ref-for-incomingstream④">9.2. Attributes</a> <a href="#ref-for-incomingstream⑤">(2)</a> <a href="#ref-for-incomingstream⑥">(3)</a>
+    <li><a href="#ref-for-incomingstream⑦">9.3. Methods</a> <a href="#ref-for-incomingstream⑧">(2)</a> <a href="#ref-for-incomingstream⑨">(3)</a>
+    <li><a href="#ref-for-incomingstream①⓪">10. Interface BidirectionalStream</a>
+    <li><a href="#ref-for-incomingstream①①">12. Interface ReceiveStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-incomingstream-readable-slot">
@@ -3754,10 +3761,10 @@ impossible to define for pooled connections.<a href="#issue-908bd92a"> ↵ </a><
   <aside class="dfn-panel" data-for="receivestream">
    <b><a href="#receivestream">#receivestream</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-receivestream">4.1. Methods</a>
-    <li><a href="#ref-for-receivestream①">9. Interface Mixin IncomingStream</a>
-    <li><a href="#ref-for-receivestream②">12. Interface ReceiveStream</a>
-    <li><a href="#ref-for-receivestream③">14.4. Receiving from ReceiveStream</a>
+    <li><a href="#ref-for-receivestream">4.1. Methods</a> <a href="#ref-for-receivestream①">(2)</a>
+    <li><a href="#ref-for-receivestream②">9. Interface Mixin IncomingStream</a>
+    <li><a href="#ref-for-receivestream③">12. Interface ReceiveStream</a>
+    <li><a href="#ref-for-receivestream④">14.4. Receiving from ReceiveStream</a>
    </ul>
   </aside>
 <script>/* script-var-click-highlighting */


### PR DESCRIPTION
This turns all getter methods for ReadableStreams and WritableStreams
into attirubtes, and renames some of them for clarity.

Fixes #54.
Fixes #101.
Fixes #132.
Fixes #133.